### PR TITLE
Update container to lambci/lambda:build-provided.al2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ $ docker run --rm \
 
 * Upgrade to Rust [`1.45.2`](https://blog.rust-lang.org/2020/08/03/Rust-1.45.2.html)
 
+* Upgrade to [amazon linux 2](https://aws.amazon.com/blogs/compute/migrating-aws-lambda-functions-to-al2/) base
+
 # 0.3.0-rust-1.45.0
 
 * Upgrade to Rust [`1.45.0`](https://blog.rust-lang.org/2020/07/16/Rust-1.45.0.html)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,19 @@
+# 0.4.0-rust-1.45.2
+
+* **Breaking change** in avoid mixed user permissions when volume mounting cargo cache directories. This docker images now configures a cargo installation to `/cargo` directory rather than `/home/root/.cargo`. You'll also want to ensure
+docker runs use a docker user that maps to your host machine's user id and group.
+
+```diff
+$ docker run --rm \
++    -u $(id -u):$(id -g) \
+    -v ${PWD}:/code \
++    -v ${HOME}/.cargo/registry:/cargo/registry \
++    -v ${HOME}/.cargo/git:/cargo/git \
+    softprops/lambda-rust
+```
+
+* Upgrade to Rust [`1.45.2`](https://blog.rust-lang.org/2020/08/03/Rust-1.45.2.html)
+
 # 0.3.0-rust-1.45.0
 
 * Upgrade to Rust [`1.45.0`](https://blog.rust-lang.org/2020/07/16/Rust-1.45.0.html)

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ FROM lambci/lambda:build-provided
 ARG RUST_VERSION=stable
 RUN yum install -y jq
 RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs \
- | sh -s -- -y --profile minimal --default-toolchain $RUST_VERSION
+ | CARGO_HOME=/cargo RUSTUP_HOME=/rustup sh -s -- -y --profile minimal --default-toolchain $RUST_VERSION
 ADD build.sh /usr/local/bin/
 VOLUME ["/code"]
 WORKDIR /code

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 # https://github.com/lambci/docker-lambda#documentation
 FROM lambci/lambda:build-provided
-ARG RUST_VERSION=stable
+ARG RUST_VERSION=1.45.2
 RUN yum install -y jq
 RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs \
  | CARGO_HOME=/cargo RUSTUP_HOME=/rustup sh -s -- -y --profile minimal --default-toolchain $RUST_VERSION

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,6 @@
 # https://github.com/lambci/docker-lambda#documentation
-FROM lambci/lambda:build-provided
+FROM lambci/lambda:build-provided.al2
+
 ARG RUST_VERSION=1.45.2
 RUN yum install -y jq
 RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs \

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-VERSION ?= 0.3.0
+VERSION ?= 0.4.0
 RUST_VERSION ?= 1.45.2
 REPO ?= softprops/lambda-rust
 TAG ?= "$(REPO):$(VERSION)-rust-$(RUST_VERSION)"

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 VERSION ?= 0.3.0
-RUST_VERSION ?= 1.45.0
+RUST_VERSION ?= 1.45.2
 REPO ?= softprops/lambda-rust
 TAG ?= "$(REPO):$(VERSION)-rust-$(RUST_VERSION)"
 

--- a/Makefile
+++ b/Makefile
@@ -16,8 +16,9 @@ test: build
 
 debug: build
 	@docker run --rm -it \
+		-u $(id -u):$(id -g) \
 		-v ${PWD}:/code \
-		-v ${HOME}/.cargo/registry:/root/.cargo/registry \
-		-v ${HOME}/.cargo/git:/root/.cargo/git  \
+		-v ${HOME}/.cargo/registry:/cargo/registry \
+		-v ${HOME}/.cargo/git:/cargo/git  \
 		--entrypoint=/bin/bash \
 		$(REPO)

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 
 ## 🤔 about
 
-This docker image extends [lambda ci `provided`](https://github.com/lambci/docker-lambda#documentation) builder docker image, a faithful reproduction of the actual AWS "**provided**" Lambda runtime environment,
+This docker image extends [lambda ci `provided.al2`](https://github.com/lambci/docker-lambda#documentation) builder docker image, a faithful reproduction of the actual AWS "**provided.al2**" Lambda runtime environment,
 and installs [rustup](https://rustup.rs/) and the *stable* rust toolchain.
 
 This provides a build environment, consistent with your target execution environment for predictable results.
@@ -99,7 +99,7 @@ You can take a look at an example [here](./tests/test-func-with-hooks).
 
 ## 🔬 local testing
 
-Once you've built a Rust lambda function artifact, the `provided` runtime expects
+Once you've built a Rust lambda function artifact, the `provided.al2` runtime expects
 deployments of that artifact to be named "**bootstrap**". The `lambda-rust` docker image
 builds a zip file, named after the binary, containing your binary file renamed to "bootstrap" for you, but zip file creation is unnecessary for local development.
 
@@ -108,7 +108,7 @@ output (not zipped) is available under `target/lambda/{profile}/output/{your-lam
 You will see both `bootstrap` and `bootstrap.debug` files there.
 > **⚠️ Note:** `PACKAGE=false` prevents `package` hook from running.
 
-You can then invoke this bootstap executable with the lambda-ci docker image for the `provided` AWS lambda runtime with a one off container.
+You can then invoke this bootstap executable with the lambda-ci docker image for the `provided.al2` AWS lambda runtime with a one off container.
 
 ```sh
 # Build your function skipping the zip creation step
@@ -122,13 +122,13 @@ docker run \
     -v ${HOME}/.cargo/git:/cargo/git \
     softprops/lambda-rust
 
-# start a one-off docker container replicating the "provided" lambda runtime
+# start a one-off docker container replicating the "provided.al2" lambda runtime
 # awaiting an event to be provided via stdin
 $ docker run \
     -i -e DOCKER_LAMBDA_USE_STDIN=1 \
     --rm \
     -v ${PWD}/target/lambda/release/output/{your-binary-name}:/var/task:ro,delegated \
-    lambci/lambda:provided
+    lambci/lambda:provided.al2
 
 # provide an event payload via stdin (typically a json blob)
 
@@ -148,7 +148,7 @@ $ unzip -o \
     -v /tmp/lambda:/var/task:ro,delegated \
     -e DOCKER_LAMBDA_STAY_OPEN=1 \
     -p 9001:9001 \
-    lambci/lambda:provided
+    lambci/lambda:provided.al2
 ```
 
 In a separate terminal, you can invoke your function with `curl`

--- a/build.sh
+++ b/build.sh
@@ -12,6 +12,9 @@ mkdir -p target/lambda
 export PROFILE=${PROFILE:-release}
 export PACKAGE=${PACKAGE:-true}
 export DEBUGINFO=${DEBUGINFO}
+export CARGO_HOME="/cargo"
+export RUSTUP_HOME="/rustup"
+
 # cargo uses different names for target
 # of its build profiles
 if [[ "${PROFILE}" == "release" ]]; then
@@ -32,7 +35,7 @@ export CARGO_TARGET_DIR=$PWD/target/lambda
     fi
 
     # source cargo
-    . $HOME/.cargo/env
+    . $CARGO_HOME/env
 
     CARGO_BIN_ARG="" && [[ -n "$BIN" ]] && CARGO_BIN_ARG="--bin ${BIN}"
 
@@ -77,7 +80,7 @@ function package() {
 
 cd "${CARGO_TARGET_DIR}/${TARGET_PROFILE}"
 (
-    . $HOME/.cargo/env
+    . $CARGO_HOME/env
     if [ -z "$BIN" ]; then
         IFS=$'\n'
         for executable in $(cargo metadata --no-deps --format-version=1 | jq -r '.packages[] | .targets[] | select(.kind[] | contains("bin")) | .name'); do

--- a/tests/test.sh
+++ b/tests/test.sh
@@ -86,7 +86,7 @@ for project in test-func test-multi-func test-func-with-hooks; do
 
     assert "it packages all bins" package_all "${bin_name}"
 
-    # verify packaged artifact by invoking it using the lambdaci "provided" docker image
+    # verify packaged artifact by invoking it using the lambdaci "provided.al2" docker image
     rm -f output.log > /dev/null 2>&1
     rm -f test-out.log > /dev/null 2>&1
     rm -rf /tmp/lambda > /dev/null 2>&1
@@ -97,7 +97,7 @@ for project in test-func test-multi-func test-func-with-hooks; do
         -i -e DOCKER_LAMBDA_USE_STDIN=1 \
         --rm \
         -v /tmp/lambda:/var/task \
-        lambci/lambda:provided < test-event.json | grep -v RequestId | grep -v '^\W*$' > test-out.log
+        lambci/lambda:provided.al2 < test-event.json | grep -v RequestId | grep -v '^\W*$' > test-out.log
 
     assert "when invoked, it produces expected output" diff expected-output.json test-out.log
 done

--- a/tests/test.sh
+++ b/tests/test.sh
@@ -12,10 +12,11 @@ source "${HERE}"/bashtest.sh
 package_bin() {
     rm -rf target/lambda/release > /dev/null 2>&1
     docker run --rm \
+    -u $(id -u):$(id -g) \
     -e BIN="$1" \
     -v "${PWD}":/code \
-    -v "${HOME}"/.cargo/registry:/root/.cargo/registry \
-    -v "${HOME}"/.cargo/git:/root/.cargo/git \
+    -v "${HOME}"/.cargo/registry:/cargo/registry \
+    -v "${HOME}"/.cargo/git:/cargo/git \
     ${IMAGE} && \
     ls target/lambda/release/"${1}".zip > /dev/null 2>&1 &&
     ls target/lambda/release/output/"${1}"/bootstrap 2>&1 &&
@@ -26,9 +27,10 @@ package_bin() {
 package_all() {
     rm -rf target/lambda/release > /dev/null 2>&1
     docker run --rm \
+    -u $(id -u):$(id -g) \
     -v "${PWD}":/code \
-    -v "${HOME}"/.cargo/registry:/root/.cargo/registry \
-    -v "${HOME}"/.cargo/git:/root/.cargo/git \
+    -v "${HOME}"/.cargo/registry:/cargo/registry \
+    -v "${HOME}"/.cargo/git:/cargo/git \
     ${IMAGE} && \
     ls target/lambda/release/"${1}".zip > /dev/null 2>&1 &&
     ls target/lambda/release/output/"${1}"/bootstrap 2>&1 &&
@@ -39,10 +41,11 @@ package_all() {
 compile_without_packaging() {
     rm -rf target/lambda/release > /dev/null 2>&1
     docker run --rm \
+    -u $(id -u):$(id -g) \
     -e PACKAGE=false \
     -v "${PWD}":/code \
-    -v "${HOME}"/.cargo/registry:/root/.cargo/registry \
-    -v "${HOME}"/.cargo/git:/root/.cargo/git \
+    -v "${HOME}"/.cargo/registry:/cargo/registry \
+    -v "${HOME}"/.cargo/git:/cargo/git \
     ${IMAGE} &&
     !(ls target/lambda/release/"${1}".zip > /dev/null 2>&1) &&
     ls target/lambda/release/output/"${1}"/bootstrap 2>&1 &&
@@ -53,10 +56,11 @@ compile_without_packaging() {
 package_all_dev_profile() {
     rm -rf target/lambda/debug > /dev/null 2>&1
     docker run --rm \
+    -u $(id -u):$(id -g) \
     -e PROFILE=dev \
     -v "${PWD}":/code \
-    -v "${HOME}"/.cargo/registry:/root/.cargo/registry \
-    -v "${HOME}"/.cargo/git:/root/.cargo/git \
+    -v "${HOME}"/.cargo/registry:/cargo/registry \
+    -v "${HOME}"/.cargo/git:/cargo/git \
     ${IMAGE} && \
     ls target/lambda/debug/"${1}".zip > /dev/null 2>&1 &&
     ls target/lambda/release/output/"${1}"/bootstrap 2>&1 &&
@@ -86,7 +90,7 @@ for project in test-func test-multi-func test-func-with-hooks; do
     rm -f output.log > /dev/null 2>&1
     rm -f test-out.log > /dev/null 2>&1
     rm -rf /tmp/lambda > /dev/null 2>&1
-    unzip -o  \
+    unzip -o \
         target/lambda/release/"${bin_name}".zip \
         -d /tmp/lambda > /dev/null 2>&1 && \
     docker run \


### PR DESCRIPTION
Required for lambdas with rocksdb dependencies.